### PR TITLE
Fix propType of "component" in <DirectLink>

### DIFF
--- a/src/DirectLink/DirectLink.js
+++ b/src/DirectLink/DirectLink.js
@@ -29,7 +29,7 @@ const DirectLink = ({ children, component, to, ...rest }) => {
 };
 
 DirectLink.propTypes = {
-  component: PropTypes.element,
+  component: PropTypes.object,
   to: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string

--- a/src/DirectLink/DirectLink.js
+++ b/src/DirectLink/DirectLink.js
@@ -29,7 +29,7 @@ const DirectLink = ({ children, component, to, ...rest }) => {
 };
 
 DirectLink.propTypes = {
-  component: PropTypes.object,
+  component: PropTypes.elementType,
   to: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string


### PR DESCRIPTION
This was given as PropTypes.element, but it seems that component classes such as stripes-components' `<Button>` are of type PropTypes.object.

Fixes a big ugly JS console error.